### PR TITLE
Do not publish to test.pypi when we do a tag release

### DIFF
--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -177,7 +177,7 @@ jobs:
   publish-testpypi-pkg:
     runs-on: ubuntu-latest
     needs: [test-artifact-pkg]
-    if: not startsWith(github.ref, 'refs/tags')
+    if: !startsWith(github.ref, 'refs/tags')
     steps:
       - name: Download Distribution
         uses: actions/download-artifact@v2
@@ -241,7 +241,7 @@ jobs:
   test-pypi-pkg:
     runs-on: ubuntu-latest
     needs: [publish-pypi-pkg]
-    if: not startsWith(github.ref, 'refs/tags')
+    if: !startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -177,6 +177,7 @@ jobs:
   publish-testpypi-pkg:
     runs-on: ubuntu-latest
     needs: [test-artifact-pkg]
+    if: not startsWith(github.ref, 'refs/tags')
     steps:
       - name: Download Distribution
         uses: actions/download-artifact@v2
@@ -240,6 +241,7 @@ jobs:
   test-pypi-pkg:
     runs-on: ubuntu-latest
     needs: [publish-pypi-pkg]
+    if: not startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -177,7 +177,7 @@ jobs:
   publish-testpypi-pkg:
     runs-on: ubuntu-latest
     needs: [test-artifact-pkg]
-    if: !startsWith(github.ref, 'refs/tags')
+    if: ! startsWith(github.ref, 'refs/tags')
     steps:
       - name: Download Distribution
         uses: actions/download-artifact@v2
@@ -241,7 +241,7 @@ jobs:
   test-pypi-pkg:
     runs-on: ubuntu-latest
     needs: [publish-pypi-pkg]
-    if: !startsWith(github.ref, 'refs/tags')
+    if: ! startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -177,7 +177,7 @@ jobs:
   publish-testpypi-pkg:
     runs-on: ubuntu-latest
     needs: [test-artifact-pkg]
-    if: ! startsWith(github.ref, 'refs/tags')
+    if: "!startsWith(github.ref, 'refs/tags')"
     steps:
       - name: Download Distribution
         uses: actions/download-artifact@v2
@@ -241,7 +241,7 @@ jobs:
   test-pypi-pkg:
     runs-on: ubuntu-latest
     needs: [publish-pypi-pkg]
-    if: ! startsWith(github.ref, 'refs/tags')
+    if: "!startsWith(github.ref, 'refs/tags')"
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
- Currently we are uploading to test.pypi on tag release, this means that we break subsequent PRs because there is a newest version than the test versions
close #4