### PR TITLE
📌 Pin dotnetcore2 version

### DIFF
--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,4 +1,4 @@
-dotnetcore2==2.1.0
+dotnetcore2==2.1.23
 flake8==3.8.4
 mypy==0.800
 pydicom==2.1.2

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,4 +1,4 @@
-dotnetcore2
+dotnetcore2==2.1.0
 flake8==3.8.4
 mypy==0.800
 pydicom==2.1.2

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,6 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     install_requires=[
-        'dotnetcore2==2.1.0'
+        'dotnetcore2==2.1.23'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ import os
 import pathlib
 from setuptools import setup, find_packages  # type: ignore
 
-
 here = pathlib.Path(__file__).parent.resolve()
 
 # Get the long description from the README file
@@ -66,6 +65,6 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     install_requires=[
-        'dotnetcore2'
+        'dotnetcore2==2.1.0'
     ],
 )

--- a/src/InnerEye_DICOM_RT/nifti_to_dicom_rt_converter.py
+++ b/src/InnerEye_DICOM_RT/nifti_to_dicom_rt_converter.py
@@ -127,11 +127,11 @@ def _wrapper(args: List[str]) -> Tuple[str, str]:
 
     # Ensure that any dependences for dotnet are downloaded.
     # This should only happen once.
-    try:
-        dependencies_path = runtime.ensure_dependencies()
-    except Exception as e:
-        logger.error('Failed to ensure dependencies %s', str(e))
-        raise
+    # try:
+    #     dependencies_path = runtime.ensure_dependencies()
+    # except Exception as e:
+    #     logger.error('Failed to ensure dependencies %s', str(e))
+    #     raise
 
     dotnet_path = runtime.get_runtime_path()
 

--- a/src/InnerEye_DICOM_RT/nifti_to_dicom_rt_converter.py
+++ b/src/InnerEye_DICOM_RT/nifti_to_dicom_rt_converter.py
@@ -127,11 +127,11 @@ def _wrapper(args: List[str]) -> Tuple[str, str]:
 
     # Ensure that any dependences for dotnet are downloaded.
     # This should only happen once.
-    # try:
-    #     dependencies_path = runtime.ensure_dependencies()
-    # except Exception as e:
-    #     logger.error('Failed to ensure dependencies %s', str(e))
-    #     raise
+    try:
+        dependencies_path = runtime.ensure_dependencies()
+    except Exception as e:
+        logger.error('Failed to ensure dependencies %s', str(e))
+        raise
 
     dotnet_path = runtime.get_runtime_path()
 


### PR DESCRIPTION
Pinning the version of the `dotnetcore2` pip package to version 2.1.0 as this is the only version that will work for the Nifti to DICOM-RT conversions. Ideally the version would be specified within a range (e.g. `<= 2.1.0`), but this is insufficient as the specific version is required by the `rtconvert` dll file to function.