### PR TITLE
🐛 Reactivate TestPyPI jobs when tagging

### DIFF
--- a/.github/workflows/build-test-pr.yml
+++ b/.github/workflows/build-test-pr.yml
@@ -177,7 +177,6 @@ jobs:
   publish-testpypi-pkg:
     runs-on: ubuntu-latest
     needs: [test-artifact-pkg]
-    if: "!startsWith(github.ref, 'refs/tags')"
     steps:
       - name: Download Distribution
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Workflows were previously not working for publishing to PyPI - the TestPyPI jobs were set to not be triggered when tagging occurred, but the PyPI publishing jobs are dependent on the completion of the TestPyPI jobs and as such were not publishing when tagging versions. This PR fixes this issue by triggering TestPyPI jobs when tagging again.  