### PR TITLE
Fix DICOM Eclipse Issue

### DIFF
--- a/RTConvert/Microsoft.RTConvert.Converters.Tests/RTEncodingTests.cs
+++ b/RTConvert/Microsoft.RTConvert.Converters.Tests/RTEncodingTests.cs
@@ -52,14 +52,12 @@ namespace Microsoft.RTConvert.Converters.Tests
 
             var outputEncoder = new DicomRTStructOutputEncoder();
 
-            var outputStructureBytes = outputEncoder.EncodeStructures(
+            var dcm = outputEncoder.EncodeStructures(
                 volumesWithMetadata,
                 new Dictionary<string, MedicalVolume>() { { "", referenceVolume } },
                 "modelX:1",
                 "manufacturer",
                 "interpreter");
-
-            var dcm = DicomFile.Open(new MemoryStream(outputStructureBytes.Array));
 
             // Check the output format (should be RT struct)
             Assert.AreEqual(DicomUID.RTStructureSetStorage, dcm.FileMetaInfo.MediaStorageSOPClassUID);

--- a/RTConvert/Microsoft.RTConvert.Converters/DicomRTStructOutputEncoder.cs
+++ b/RTConvert/Microsoft.RTConvert.Converters/DicomRTStructOutputEncoder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.RTConvert.Converters
 
         public SegmentationOutputEncoding OutputEncoding => SegmentationOutputEncoding.RTStruct;
 
-        public ArraySegment<byte> EncodeStructures(
+        public DicomFile EncodeStructures(
             IEnumerable<(string name, Volume3D<byte> volume, RGBColor color, bool fillHoles, ROIInterpretedType roiInterpretedType)> outputStructuresWithMetadata,
             IReadOnlyDictionary<string, MedicalVolume> inputChannels,
             string modelNameAndVersion,
@@ -40,21 +40,7 @@ namespace Microsoft.RTConvert.Converters
                 manufacturer,
                 interpreter);
 
-            return SerializeDicomFile(structureSetFile);
-        }
-
-        private static ArraySegment<byte> SerializeDicomFile(DicomFile structureSetFile)
-        {
-            using (var memoryStream = new MemoryStream())
-            {
-                structureSetFile.Save(memoryStream);
-
-                if (!memoryStream.TryGetBuffer(out ArraySegment<byte> output))
-                {
-                    throw new InvalidOperationException("Could not extract Array-Segment instance from Memory-Stream");
-                }
-                return output;
-            }
+            return structureSetFile;
         }
 
         private static DicomFile CreateStructureSetFile(

--- a/RTConvert/Microsoft.RTConvert.Converters/ISegmentationOutputEncoder.cs
+++ b/RTConvert/Microsoft.RTConvert.Converters/ISegmentationOutputEncoder.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.RTConvert.Converters
 {
+    using Dicom;
     using Microsoft.RTConvert.MedIO.Models;
     using Microsoft.RTConvert.MedIO.RT;
     using Microsoft.RTConvert.Models;
@@ -40,7 +41,7 @@ namespace Microsoft.RTConvert.Converters
         SegmentationOutputEncoding OutputEncoding { get; }
 
         /// <summary>
-        /// Encodes the segmentation output in a binary format. 
+        /// Encodes the segmentation output into a DicomFile object. 
         /// </summary>
         /// <param name="outputStructures">The output structures from eh machine learning</param>
         /// <param name="inputChannels">The input channels that were used to generate the structures</param>
@@ -48,7 +49,7 @@ namespace Microsoft.RTConvert.Converters
         /// <param name="manufacturer">The creator of the model.</param>
         /// <param name="interpreter">The interpreter of the model.</param>
         /// <returns></returns>
-        ArraySegment<byte> EncodeStructures(
+        DicomFile EncodeStructures(
               IEnumerable<(string name, Volume3D<byte> volume, RGBColor color, bool fillHoles, ROIInterpretedType roiInterpretedType)> outputStructures,
               IReadOnlyDictionary<string, MedicalVolume> inputChannels,
               string modelAndVersion,

--- a/RTConvert/Microsoft.RTConvert.Converters/RTConverters.cs
+++ b/RTConvert/Microsoft.RTConvert.Converters/RTConverters.cs
@@ -275,14 +275,14 @@ namespace Microsoft.RTConvert.Converters
 
             var outputEncoder = new DicomRTStructOutputEncoder();
 
-            var outputStructureBytes = outputEncoder.EncodeStructures(
+            var outputDicomFile = outputEncoder.EncodeStructures(
                 volumesWithMetadata,
                 new Dictionary<string, MedicalVolume>() { { "", referenceVolume } },
                 modelNameAndVersion,
                 manufacturer,
                 interpreter);
 
-            File.WriteAllBytes(dcmFilename, outputStructureBytes.Array);
+            outputDicomFile.Save(dcmFilename);
         }
     }
 }

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,5 +1,5 @@
 dotnetcore2==2.1.23
-flake8==3.8.4
+flake8==5.0.4
 mypy==0.800
 pydicom==2.1.2
 pytest-cov==2.11.1

--- a/tests/test_nifti_to_dicom_rt_converter.py
+++ b/tests/test_nifti_to_dicom_rt_converter.py
@@ -77,48 +77,44 @@ TestDicomVolumeLocation: Path = TEST_DATA_DIR / "HN"
 TestOutputFile: Path = THIS_DIR / "test.dcm"
 
 # Test fill holes.
-FillHoles: List[bool] = \
-    [
-        True, True, True, True,
-        False, False, True, True,
-        True, True, False, True,
-        True, True, True, False,
-        True, False, True, True,
-        False, True
-    ]
+FillHoles: List[bool] = [
+    True, True, True, True,
+    False, False, True, True,
+    True, True, False, True,
+    True, True, True, False,
+    True, False, True, True,
+    False, True
+]
 
 # Test ROIInterpretedType.
-ROIInterpretedTypes: List[str] = \
-    [
-        "ORGAN", "None", "CTV", "EXTERNAL",
-        "ORGAN", "None", "CTV", "EXTERNAL",
-        "ORGAN", "None", "CTV", "EXTERNAL",
-        "ORGAN", "None", "CTV", "EXTERNAL",
-        "ORGAN", "None", "CTV", "EXTERNAL",
-        "ORGAN", "None"
-    ]
+ROIInterpretedTypes: List[str] = [
+    "ORGAN", "None", "CTV", "EXTERNAL",
+    "ORGAN", "None", "CTV", "EXTERNAL",
+    "ORGAN", "None", "CTV", "EXTERNAL",
+    "ORGAN", "None", "CTV", "EXTERNAL",
+    "ORGAN", "None", "CTV", "EXTERNAL",
+    "ORGAN", "None"
+]
 
 # Test structure colors.
-StructureColors: List[str] = \
-    [
-        "FF0001", "FF0002", "FF0003", "FF0004",
-        "FF0101", "FF0102", "FF0103", "FF0103",
-        "FF0201", "FF02FF", "FF0203", "FF0204",
-        "FF0301", "FF0302", "01FF03", "FF0304",
-        "FF0401", "00FFFF", "FF0403", "FF0404",
-        "FF0501", "FF0502"
-    ]
+StructureColors: List[str] = [
+    "FF0001", "FF0002", "FF0003", "FF0004",
+    "FF0101", "FF0102", "FF0103", "FF0103",
+    "FF0201", "FF02FF", "FF0203", "FF0204",
+    "FF0301", "FF0302", "01FF03", "FF0304",
+    "FF0401", "00FFFF", "FF0403", "FF0404",
+    "FF0501", "FF0502"
+]
 
 # Test structure names.
-StructureNames: List[str] = \
-    [
-        "External", "parotid_l", "parotid_r", "smg_l",
-        "smg_r", "spinal_cord", "brainstem", "globe_l",
-        "Globe_r", "mandible", "spc_muscle", "mpc_muscle",
-        "Cochlea_l", "cochlea_r", "lens_l", "lens_r",
-        "optic_chiasm", "optic_nerve_l", "optic_nerve_r", "pituitary_gland",
-        "lacrimal_gland_l", "lacrimal_gland_r"
-    ]
+StructureNames: List[str] = [
+    "External", "parotid_l", "parotid_r", "smg_l",
+    "smg_r", "spinal_cord", "brainstem", "globe_l",
+    "Globe_r", "mandible", "spc_muscle", "mpc_muscle",
+    "Cochlea_l", "cochlea_r", "lens_l", "lens_r",
+    "optic_chiasm", "optic_nerve_l", "optic_nerve_r", "pituitary_gland",
+    "lacrimal_gland_l", "lacrimal_gland_r"
+]
 
 Manufacturer = "Contosos"
 Interpreter = "Ai"


### PR DESCRIPTION
It seems that the cause of the erroneous encoding has something to do with the use of the C# `MemoryStream` for saving the DICOM files. If using the `DicomFile.Save(string filename)` functionality instead, the saved file loads into DICOM+ and Eclipse with no reported errors.

Closes #6 